### PR TITLE
docs: add ToC to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,33 @@
 
 **Aubade** is a retro-brutalist theme for [Obsidian](https://obsidian.md). It prioritises strict geometry, high contrast, and tactile interactions over soft gradients and rounded corners. Designed for users who require their digital workspace to feel like a structural tool.
 
+# Table of contents
+
+<!--toc:start-->
+- [Visual Identity](#visual-identity)
+- [Colour Schemes](#colour-schemes)
+- [Select your favourite pattern](#select-your-favourite-pattern)
+- [Key Features](#key-features)
+- [Typography](#typography)
+  - [Sans Serif](#sans-serif)
+  - [Monospace](#monospace)
+- [Layout & Configuration](#layout--configuration)
+  - [Alignment](#alignment)
+  - [Note Width Control](#note-width-control)
+  - [Typography Settings](#typography-settings)
+- [Per-Note Overrides](#per-note-overrides)
+  - [Custom Widths](#custom-widths)
+  - [Interface Hiding](#interface-hiding)
+- [Dashboard & Masonry Layout](#dashboard--masonry-layout)
+  - [CSS-Only Timelines](#css-only-timelines)
+- [Installation](#installation)
+  - [Method 1: Community Themes (CURRENTLY PENDING REVIEW BY OBSIDIAN)](#method-1-community-themes-currently-pending-review-by-obsidian)
+  - [Method 2: Manual Installation](#method-2-manual-installation)
+- [Gallery](#gallery)
+  - [Dark Mode](#dark-mode)
+  - [Light Mode](#light-mode)
+<!--toc:end-->
+
 ## Visual Identity
 
 * **Strict Geometry:** A zero-radius policy applied globally. Every corner is sharp; every container is a box.


### PR DESCRIPTION
Since the screenshots take a lot of space and the content is growing, it's not the most convenient to scroll to a specific feature in the README - like to the new timelines section. I think it's useful to have a ToC, so the user can go to specific sections immediately instead of scrolling and scrolling.

Feel free to close the PR if you don't like it or don't see any value in this change!

(The ToC was generated by [marksman](https://github.com/artempyanykh/marksman/blob/main/docs/features.md#table-of-contents).)